### PR TITLE
Fix Windows crash

### DIFF
--- a/examples/react-colyseus/packages/server/package.json
+++ b/examples/react-colyseus/packages/server/package.json
@@ -8,6 +8,7 @@
     "start:dev": "node ./dist/app.js",
     "start:prod": "NODE_ENV=production PORT=3000 node ./dist/app.js",
     "dev": "nodemon --watch src -e ts,ejs --exec $npm_execpath start",
+    "dev:win": "nodemon --watch src -e ts,ejs --exec %npm_execpath% start",
     "build": "npm-run-all build:clean build:tsc",
     "build:clean": "rimraf dist/*",
     "build:tsc": "tsc",


### PR DESCRIPTION
Environment variables are referenced differently depending on the operating system. 

On Unix-like operating systems such as macOS and Linux, they are referenced using a dollar sign ($) prefix. For example:

```bash
$npm_execpath
^
```

On Windows, they are referenced using a percent sign (%) on both sides. For example:

```batch
%npm_execpath%
^            ^
```

The solution applied involves accommodating this difference in referencing environment variables between Unix-like systems and Windows. 

Original:
```json
"dev": "nodemon --watch src -e ts,ejs --exec $npm_execpath start",
```

Updated:
```json
"dev": "nodemon --watch src -e ts,ejs --exec $npm_execpath start",
"dev:win": "nodemon --watch src -e ts,ejs --exec %npm_execpath% start",
```

In the updated version, a separate script `dev:win` is added to cater to Windows systems, where `%npm_execpath%` is used to reference the environment variable instead of `$npm_execpath`. This ensures compatibility across different operating systems.